### PR TITLE
:pencil2: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Studenarbeit
+## Studienarbeit Implementierung
 
 ### :clipboard: Titel
 Entwicklung und Implementierung eines Ausweichalgorithmus zur Kollisionsprävention von Objekten mit Wiederaufnahme der Ursprungsroute.


### PR DESCRIPTION
- fixes 'Studenarbeit' to 'Studienarbeit'